### PR TITLE
Fix hero section responsive layout and spacing issues

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -34,6 +34,12 @@ body {
   max-width: 680px;
 }
 
+.hero-background {
+  background-image: url("https://img.funnelish.com/10843/79553/1681836756-main-sec.png?auto=webp&clip=bounds");
+  background-size: cover;
+  background-position: center;
+}
+
 .paragraph-inner {
   margin-top: 1rem;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
         <div className="absolute inset-0 bg-cover bg-center hero-background" />
         <div className="absolute inset-0 bg-black/30" />
 
-        <div className="relative container mx-auto max-w-[1200px] px-2 sm:px-4 flex flex-col lg:flex-row items-center justify-center lg:justify-between gap-6 h-auto min-h-[520px] lg:h-[560px]">
+        <div className="relative container mx-auto max-w-[1200px] px-2 sm:px-4 flex flex-col md:flex-row items-center justify-center md:justify-between gap-6 h-auto min-h-[520px] md:h-[560px]">
           {/* Left: Text Card */}
           <div className="hero-content z-20 max-w-[680px] rounded-2xl p-6 sm:p-8 text-white">
             <div className="hero-logo mt-2"><NextImage src="/logo.png" alt="Exiscale logo" width={64} height={64} className="hero-logo-img" /><span className="ml-2 font-extrabold text-2xl bg-gradient-to-r from-[#ff7a2f] to-[#ff9a60] bg-clip-text text-transparent tracking-wide">Wolves</span></div>
@@ -105,7 +105,7 @@ export default function Home() {
           </div>
 
           {/* Right: Banner image overlapping */}
-          <div className="hero-image block relative z-30 mt-6 lg:mt-0 lg:absolute lg:right-10 lg:bottom-0">
+          <div className="hero-image block relative z-30 mt-6 md:mt-0 md:absolute md:right-10 md:bottom-0">
             <NextImage
               src="/anhbanner.webp"
               alt="Banner person"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,10 +44,10 @@ export default function Home() {
     <div className="font-sans min-h-screen bg-background text-foreground">
       {/* Hero Banner */}
       <section className="relative hero-section">
-        <div className="absolute inset-0 bg-cover bg-center" style={{backgroundImage: 'url("https://img.funnelish.com/10843/79553/1681836756-main-sec.png?auto=webp&clip=bounds")'}} />
+        <div className="absolute inset-0 bg-cover bg-center hero-background" />
         <div className="absolute inset-0 bg-black/30" />
 
-        <div className="relative container mx-auto px-2 sm:px-4 flex items-center h-[500px] sm:h-[560px] justify-start">
+        <div className="relative container mx-auto max-w-[1200px] px-2 sm:px-4 flex flex-col lg:flex-row items-center justify-center lg:justify-between gap-6 h-auto min-h-[520px] lg:h-[560px]">
           {/* Left: Text Card */}
           <div className="hero-content z-20 max-w-[680px] rounded-2xl p-6 sm:p-8 text-white">
             <div className="hero-logo mt-2"><NextImage src="/logo.png" alt="Exiscale logo" width={64} height={64} className="hero-logo-img" /><span className="ml-2 font-extrabold text-2xl bg-gradient-to-r from-[#ff7a2f] to-[#ff9a60] bg-clip-text text-transparent tracking-wide">Wolves</span></div>
@@ -105,14 +105,14 @@ export default function Home() {
           </div>
 
           {/* Right: Banner image overlapping */}
-          <div className="hero-image hidden sm:block absolute right-10 bottom-0 z-30">
+          <div className="hero-image block relative z-30 mt-6 lg:mt-0 lg:absolute lg:right-10 lg:bottom-0">
             <NextImage
               src="/anhbanner.webp"
               alt="Banner person"
               width={580}
               height={580}
               priority
-              className="object-contain scale-100"
+              className="object-contain scale-100 w-[220px] sm:w-[360px] lg:w-[480px] xl:w-[560px] h-auto"
             />
           </div>
         </div>


### PR DESCRIPTION
## Purpose
Fix responsive layout issues in the hero section where elements were not properly balanced across different screen sizes. The user reported that at 992px the text and banner image were well-balanced, but at 1920x1080 they were too far apart, and on mobile the banner image was completely missing due to poor responsive design.

## Code changes
- **Container improvements**: Added `max-w-[1200px]` constraint and switched to flexbox layout with `flex-col md:flex-row` for better responsive behavior
- **Layout restructuring**: Changed from absolute positioning to responsive flex layout with `justify-center md:justify-between` and proper gap spacing
- **Mobile responsiveness**: Removed `hidden sm:block` from banner image and made it visible on all screen sizes with responsive sizing
- **Image scaling**: Added responsive width classes (`w-[220px] sm:w-[360px] lg:w-[480px] xl:w-[560px]`) for proper scaling across devices
- **CSS optimization**: Moved inline background styles to a dedicated `.hero-background` CSS class for better maintainability
- **Height adjustments**: Changed from fixed height to `min-h-[520px] md:h-[560px]` with `h-auto` for flexible content sizing

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e3b336d7481a48078a7b4de3b8878d57/mystic-haven)

👀 [Preview Link](https://e3b336d7481a48078a7b4de3b8878d57-mystic-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e3b336d7481a48078a7b4de3b8878d57</projectId>-->
<!--<branchName>mystic-haven</branchName>-->